### PR TITLE
ARM: tegra: tegra124: nyan: enable HDMI CEC

### DIFF
--- a/arch/arm/boot/dts/tegra124-nyan.dtsi
+++ b/arch/arm/boot/dts/tegra124-nyan.dtsi
@@ -57,6 +57,10 @@
 			status = "okay";
 		};
 	};
+	
+	cec@70015000 {
+		status = "okay";
+	};
 
 	gpu@0,57000000 {
 		status = "okay";


### PR DESCRIPTION
This patch enables HDMI CEC for all nyan devices.